### PR TITLE
조회수 기반 상품 수정

### DIFF
--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -36,8 +36,6 @@ async function handler(
       orderBy: {
         createdAt: "desc",
       },
-      take: 15,
-      skip: 15 * +page,
     });
     if (views.length === 0) {
       return res.json({
@@ -99,9 +97,15 @@ async function handler(
       newProducts = [...newProducts, ...subProducts];
     }
 
+    const splicedProducts = newProducts.splice(15 * +page, 15);
+
     res.json({
       ok: true,
-      products: newProducts,
+      products: [
+        ...splicedProducts.splice(0, 3),
+        ...splicedProducts.splice(3, 3),
+        ...splicedProducts,
+      ],
     });
   }
   if (req.method === "POST") {


### PR DESCRIPTION
Infinit scoll로 인해 15개씩 상품을 불러오면서 조회수를 기반으로 상품 출력이 정확히 안됩니다.

전체 상품을 15개 splice해서 반환하도록 변경했습니다.